### PR TITLE
//Workaround Set ServerSettings before callback login

### DIFF
--- a/server.go
+++ b/server.go
@@ -466,3 +466,47 @@ func recoverState() {
 	//
 	fmt.Println("State recovery successful")
 }
+
+//Workaround Set ServerSettings before callback login
+func UpdateSettings(s *ServerSettings) {
+	// Default localhost settings
+		fmt.Println("Using default workaround settings...")
+		settings = &ServerSettings{
+			ServerName:     "myserv",
+			MaxConnections: 2,
+
+			HostName:  "localhost",
+			HostAlias: "localhost",
+			IP:        "localhost",
+			Port:      8080,
+
+			TLS:         false,
+			CertFile:    "",
+			PrivKeyFile: "",
+
+			OriginOnly: false,
+
+			MultiConnect:   false,
+			KickDupOnLogin: false,
+
+			UserRoomControl:   true,
+			RoomDeleteOnLeave: true,
+
+			EnableSqlFeatures: false,
+			SqlIP:             "localhost",
+			SqlPort:           3306,
+			SqlProtocol:       "tcp",
+			SqlUser:           "user",
+			SqlPassword:       "password",
+			SqlDatabase:       "database",
+			EncryptionCost:    4,
+			CustomLoginColumn: "",
+			RememberMe:        false,
+
+			EnableRecovery:   false,
+			RecoveryLocation: "C:/",
+
+			AdminLogin:    "admin",
+			AdminPassword: "password"}
+	}
+} 


### PR DESCRIPTION
added the func UpdateSettings(s *ServerSettings)   in server.go
to be able to set the settings before the first logincallback